### PR TITLE
unicode-transforms fails to build with text-1.1.0.0

### DIFF
--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -83,7 +83,7 @@ library
       base >= 4.7 && < 5
     , bitarray   >= 0.0.1 && < 0.1
     , bytestring >= 0.9   && < 0.11
-    , text       >= 0.1   && < 1.3
+    , text       >= 1.1.1 && < 1.3
   if flag(dev)
     ghc-options: -O0
   else


### PR DESCRIPTION
I'm getting the following build failure:

```
[ 9 of 12] Compiling Data.Unicode.Internal.NormalizeStream ( Data/Unicode/Internal/NormalizeStream.hs, dist/dist-sandbox-f055f97e/build/Data/Unicode/Internal/NormalizeStream.o )

Data/Unicode/Internal/NormalizeStream.hs:29:58:
    Module
    ‘Data.Text.Internal.Fusion.Size’
    does not export
    ‘betweenSize’
cabal: Leaving directory '/var/folders/d1/v9ptqpx12mdcxj77509440rc0000gn/T/cabal-tmp-46930/unicode-transforms-0.2.0'
Updating documentation index
/Users/ppelleti/programming/haskell/normalize/normalization-insensitive/.cabal-sandbox/share/doc/x86_64-osx-ghc-7.8.3/index.html
cabal: Error: some packages failed to install:
unicode-transforms-0.2.0 failed during the building phase. The exception was:
ExitFailure 1
```

My cabal sandbox is using `text-1.1.0.0`, which is perfectly legal, because `unicode-transforms` says it will work with anything back to `text-0.1`:

```
  build-depends:
      base >= 4.7 && < 5
    , bitarray   >= 0.0.1 && < 0.1
    , bytestring >= 0.9   && < 0.11
    , text       >= 0.1   && < 1.3
```

However, `betweenSize` was introduced in `text-1.1.1.0`, so this pull request proposes that should be the lower bound for `text`.  This probably ought to be fixed retroactively on Hackage, as well as going forward.
