### PR TITLE
Update package.yaml

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -148,7 +148,7 @@ benchmarks:
 
     source-dirs: benchmark
     main:        Benchmark.hs
-    other-modules: .
+    other-modules: []
 
     dependencies:
       - criterion            >= 1.1.1 && < 1.3

--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -190,6 +190,4 @@ benchmark bench
   if impl(ghc < 7.10)
     build-depends:
         path (< 0.5.12 || > 0.5.12)
-  other-modules:
-      .
   default-language: Haskell2010


### PR DESCRIPTION
`hpack` doesn't seem to validate valid names. `.` worked by accident as current Cabal-file parser is too lax.